### PR TITLE
rename typescript package to conjure-examples-api

### DIFF
--- a/example-api/build.gradle
+++ b/example-api/build.gradle
@@ -30,9 +30,9 @@ project (':example-api:example-api-typescript') {
     }
 }
 
-// optional, only needed if want to override the default settings
+// optional, only needed if you want to override the default settings
 conjure {
     typescript {
-        packageName = "conjure-examples-api" // default package name is the project name, example-api
+        packageName = "conjure-examples-api" // default package name is the project name, `example-api`
     }
 }


### PR DESCRIPTION
I think  it is important that the api is prefixed with `conjure`