### PR TITLE
Typo: Its celSius

### DIFF
--- a/recipe-example-server/var/conf/recipes.yml
+++ b/recipe-example-server/var/conf/recipes.yml
@@ -30,6 +30,6 @@ recipes:
         bake:
           temperature:
             degree: 220
-            unit: "CELCIUS"
+            unit: "CELSIUS"
           durationInSeconds: 2700
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Celsius

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
The unit is correctly named CEL**S**IUS
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

